### PR TITLE
chat: Plumb highlights from avatars to chat.

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -3,6 +3,7 @@
 import React, { createRef } from 'react';
 import { Redirect } from 'react-router-dom';
 import { RouteComponentProps } from 'react-router';
+import { useDispatch } from 'react-redux';
 
 // Internal
 
@@ -176,7 +177,7 @@ class Game extends React.PureComponent<RouteComponentProps<GameProps>, GameState
         <AvalonScrollbars>
           <div id="Game" style={{ minHeight: this.initialHeight + 'px' }} className="section">
             <div className="column section" style={{ flex: '0 0 ' + (40 + this.state.scale * 20) + '%' }}>
-              <Table ref={this.tableRef} game={this.state} />
+              <Table ref={this.tableRef} game={this.state} dispatch={useDispatch}/>
             </div>
             <div className="column section">{tabs}</div>
           </div>

--- a/src/pages/Game/AvatarUI.tsx
+++ b/src/pages/Game/AvatarUI.tsx
@@ -4,6 +4,8 @@ import React, { createRef } from 'react';
 import { faStamp, faPen, faPaintBrush, faCheck, faGavel, faAddressCard } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { SketchPicker, ColorResult, RGBColor } from 'react-color';
+import { connect } from "react-redux";
+import { updateChatHighlight } from "../../redux/actions";
 
 // Import Internal Components
 
@@ -16,11 +18,12 @@ import '../../styles/Game/AvatarUI.scss';
 
 // Class Definition
 
-class AvatarUI extends React.PureComponent<
+export class AvatarUI extends React.PureComponent<
   AvatarUIProps,
   {
     currentBackground: number;
     currentHighlight: RGBColor;
+    highlightChat: boolean,
     renderPicker: boolean;
     renderButtons: boolean;
     avatarSelected: boolean;
@@ -39,11 +42,13 @@ class AvatarUI extends React.PureComponent<
         b: 0,
         a: 100,
       },
+      highlightChat: false,
       renderPicker: false,
       renderButtons: false,
       avatarSelected: false,
     };
     this.handleHighlight = this.handleHighlight.bind(this);
+    this.toggleHighlightChat = this.toggleHighlightChat.bind(this);
   }
 
   componentDidUpdate(prevProps: AvatarUIProps) {
@@ -54,8 +59,31 @@ class AvatarUI extends React.PureComponent<
     }
   }
 
+  toggleHighlightChat() {
+    const enable = !this.state.highlightChat;
+    this.setState({highlightChat: enable});
+    if (enable) {
+      this.highlightChat();
+    } else {
+      this.props.dispatch(updateChatHighlight(this.props.username, 'transparent'));
+    }
+  }
+
+  toHtmlHex(color: RGBColor) {
+    const toHex = (num: number) => { return num.toString(16).padStart(2, '0'); }
+    return '#' + toHex(color.r) + toHex(color.g) + toHex(color.b);
+  }
+
+  highlightChat() {
+    const color = this.state.currentHighlight;
+    this.props.dispatch(updateChatHighlight(this.props.username, this.toHtmlHex(color)));
+  }
+
   handleHighlight(color: ColorResult) {
     this.setState({ currentHighlight: color.rgb });
+    if (this.state.highlightChat) {
+      this.highlightChat();
+    }
   }
 
   renderButtonsTrue = () => this.setState({ renderButtons: true });
@@ -152,9 +180,9 @@ class AvatarUI extends React.PureComponent<
                   <span className="tooltip-text">Mark this player's allegiance</span>
                   <FontAwesomeIcon icon={faStamp} />
                 </button>
-                <button className="tooltip">
+                <button onClick={this.toggleHighlightChat} className="tooltip">
                   <span className="tooltip-text">Highlight this player's chat messages</span>
-                  <FontAwesomeIcon icon={faPen} />
+                  <FontAwesomeIcon style={{backgroundColor: this.state.highlightChat ? this.toHtmlHex(this.state.currentHighlight) : ''}} icon={faPen} />
                 </button>
                 <button onClick={this.showColorPicker} className="tooltip">
                   <span className="tooltip-text">Change this player's highlight color</span>
@@ -201,4 +229,4 @@ class AvatarUI extends React.PureComponent<
   }
 }
 
-export default AvatarUI;
+export default connect(null, null, null, { forwardRef: true })(AvatarUI);

--- a/src/pages/Game/AvatarUIProps.tsx
+++ b/src/pages/Game/AvatarUIProps.tsx
@@ -1,3 +1,10 @@
+// External
+
+import { Dispatch } from 'redux';
+
+
+// Internal
+
 import Table from './Table';
 
 interface AvatarUIProps {
@@ -24,6 +31,7 @@ interface AvatarUIProps {
   avatarPosition: [number, number];
   avatarShow: boolean;
   avatarSize: number;
+  dispatch: Dispatch;
 }
 
 type AvatarUIPropsType = AvatarUIProps;

--- a/src/pages/Game/Table.tsx
+++ b/src/pages/Game/Table.tsx
@@ -2,13 +2,14 @@
 
 import React, { createRef, RefObject } from 'react';
 import { Redirect } from 'react-router-dom';
+import { Dispatch } from 'redux';
 
 // Internal
 
 import AvatarUIProps from './AvatarUIProps';
 import StatusBar from './StatusBar';
 import GameState from './GameState';
-import AvatarUI from './AvatarUI';
+import ConnectedAUI, { AvatarUI } from './AvatarUI';
 import Button from '../../components/utils/Button';
 
 // Styles
@@ -19,6 +20,7 @@ import '../../styles/Game/Table.scss';
 
 interface TableProps {
   game: GameState;
+  dispatch: Dispatch;
 }
 
 class MissionTracker extends React.PureComponent<{ count: number; results: boolean[]; round: number }, {}> {
@@ -204,6 +206,7 @@ class Table extends React.PureComponent<
         avatarShow: ave ? ave.avatarShow : false,
         avatarSize: ave ? ave.avatarSize : 350,
         tableWidth: ave ? ave.tableWidth : 0,
+        dispatch: this.props.dispatch,
       };
 
       avatars.push(output);
@@ -455,7 +458,7 @@ class Table extends React.PureComponent<
     this.setState({
       redirect: true,
     });
-  }; 
+  };
 
   render() {
     const avatars = this.state.avatars;
@@ -466,7 +469,7 @@ class Table extends React.PureComponent<
 
       mappedAvatars.push(
         <div className="table-seat" ref={this.seatRef[i]} key={'Seat' + i}>
-          <AvatarUI {...a} table={this} ref={this.avatarRef[i]} />
+          <ConnectedAUI {...a} table={this} ref={this.avatarRef[i]} />
         </div>
       );
     }

--- a/src/pages/Game/Tabs.tsx
+++ b/src/pages/Game/Tabs.tsx
@@ -62,8 +62,8 @@ class Tabs extends React.PureComponent<TabContainerProps, TabContainerState> {
 
   render() {
     const routes = [
-      <Chat players={[]} stage={'NONE'} key="genChat" />,
-      <Chat code={this.props.game.code} players={this.props.game.players} stage={this.props.game.stage} key="gameChat" />,
+      <Chat players={[]} stage={'NONE'} chatHighlights={{}} key="genChat" />,
+      <Chat code={this.props.game.code} players={this.props.game.players} stage={this.props.game.stage} chatHighlights={{}} key="gameChat" />,
       <Notes notes="" dispatch={useDispatch} />,
       <VoteHistory game={this.props.game} />,
       <PlayerList code={this.props.game.code} players={this.props.game.players} clients={this.props.game.clients} />,

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -35,7 +35,7 @@ class Lobby extends React.PureComponent {
               <PlayerList players={[]} clients={[]} />
             </div>
             <div className="column section">
-              <Chat players={[]} stage={'NONE'}/>
+              <Chat chatHighlights={{}} players={[]} stage={'NONE'}/>
             </div>
             <div className="column section">
               <GameList />

--- a/src/pages/Lobby/Chat.tsx
+++ b/src/pages/Lobby/Chat.tsx
@@ -2,12 +2,14 @@
 
 import React, { ChangeEvent, FormEvent, createRef } from 'react';
 import { Link } from 'react-router-dom';
+import { connect } from "react-redux";
 
 // Internal
 
 import socket from '../../socket-io/socket-io';
 import AvalonScrollbars from '../../components/utils/AvalonScrollbars';
 import { ChatInput } from '../../components/utils/Input';
+import { rootType } from "../../redux/reducers";
 
 // Styles
 
@@ -29,12 +31,18 @@ interface ChatProps {
   code?: string;
   players: string[];
   stage?: string;
+  chatHighlights: { [key: string]: string; };
 }
 
 interface ChatState {
   messages: ChatSnapshot[];
   content: string;
 }
+
+const mapState = (state: rootType) => {
+  const { chatHighlights } = state;
+  return { chatHighlights };
+};
 
 class Chat extends React.PureComponent<ChatProps, ChatState> {
   scrollbars = createRef<AvalonScrollbars>();
@@ -57,7 +65,7 @@ class Chat extends React.PureComponent<ChatProps, ChatState> {
   }
 
   componentDidMount() {
-    if (this.props.code === undefined) {
+   if (this.props.code === undefined) {
       this.startChat();
     } else if (this.props.code !== '-1') {
       this.toGameChat();
@@ -133,12 +141,14 @@ class Chat extends React.PureComponent<ChatProps, ChatState> {
     const messageClass = classType + classCharacter + classSpectator;
     const messageAuthor = snap.type < 1 ? snap.author : undefined;
     const messageContent = snap.content;
+    const messageHighlight = (messageAuthor && messageAuthor in this.props.chatHighlights) ?
+        this.props.chatHighlights[messageAuthor] : '';
 
     const messageDate = new Date(snap.timestamp);
     const messageHour = ('0' + messageDate.getHours()).slice(-2) + ':' + ('0' + messageDate.getMinutes()).slice(-2);
 
     return (
-      <div className={'message ' + messageClass}>
+      <div className={'message ' + messageClass} style={{backgroundColor: messageHighlight}}>
         <span className="hour">{messageHour}</span>
         <p className="text">
           {messageAuthor ? (
@@ -174,4 +184,4 @@ class Chat extends React.PureComponent<ChatProps, ChatState> {
   }
 }
 
-export default Chat;
+export default connect(mapState, null)(Chat);

--- a/src/redux/actions.tsx
+++ b/src/redux/actions.tsx
@@ -4,6 +4,7 @@ export const ADD_NOTES = "ADD_NOTES";
 export const SET_USERNAME = "SET_USERNAME";
 export const SET_ONLINE = "SET_ONLINE";
 export const SET_GAME_TAB_HIGHLIGHT = "SET_HIGHLIGHT";
+export const UPDATE_CHAT_HIGHLIGHT = "UPDATE_CHAT_HIGHLIGHT";
 
 interface AddNotesAction {
   type: typeof ADD_NOTES;
@@ -26,7 +27,13 @@ interface SetOnlineAction {
   value: boolean;
 }
 
-export type ActionTypes = AddNotesAction | SetGameTabHighlight | SetUsernameAction | SetOnlineAction;
+interface UpdateChatHighlight {
+  type: typeof UPDATE_CHAT_HIGHLIGHT;
+  player: string;
+  color: string;
+}
+
+export type ActionTypes = AddNotesAction | SetGameTabHighlight | SetUsernameAction | SetOnlineAction | UpdateChatHighlight;
 
 // Actions
 
@@ -56,5 +63,13 @@ export function setOnline(value: boolean): ActionTypes {
   return {
     type: SET_ONLINE,
     value,
+  };
+}
+
+export function updateChatHighlight(player: string, color: string) {
+  return {
+    type: UPDATE_CHAT_HIGHLIGHT,
+    player: player,
+    color: color,
   };
 }

--- a/src/redux/reducers.tsx
+++ b/src/redux/reducers.tsx
@@ -4,7 +4,7 @@ import { combineReducers } from "redux";
 
 // Types
 
-import { ADD_NOTES, SET_USERNAME, SET_ONLINE, SET_GAME_TAB_HIGHLIGHT, ActionTypes } from "./actions";
+import { ADD_NOTES, SET_USERNAME, SET_ONLINE, SET_GAME_TAB_HIGHLIGHT, UPDATE_CHAT_HIGHLIGHT, ActionTypes } from "./actions";
 
 // Reducers
 
@@ -45,11 +45,23 @@ function highlighted(state: boolean[] = [false, false, false, false, false], act
 	}
 }
 
+function chatHighlights(state: { [key: string]: string } = {}, action: ActionTypes): { [key: string]: string } {
+	switch (action.type) {
+		case UPDATE_CHAT_HIGHLIGHT:
+			const newState = { ...state };
+			newState[action.player] = action.color;
+			return newState;
+		default:
+			return state;
+	}
+}
+
 export const rootReducer = combineReducers({
 	notes,
 	username,
 	online,
-	highlighted
+	highlighted,
+	chatHighlights
 });
 
 export type rootType = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
Store the highlights as a map between player name and HTML color and put
these in the game state, since that is the state that is shared between
all the Table components. When building the chat messages, check the
chatHighlights for the color and apply it.

TODO:
 - Respect the ok button on the color picker. Right now, you must move
   the color in the color picker in order for it to be accepted.
 - Immediately update the highlight. Currently, the chat component needs
   to be updated externally and does not update highlights as soon as
   they are selected in the color picker.